### PR TITLE
Fixes #16 - Webpack i18n Translations

### DIFF
--- a/nativescript/webpack.common.js
+++ b/nativescript/webpack.common.js
@@ -33,6 +33,7 @@ module.exports = function (platform, destinationApp) {
         new CopyWebpackPlugin([
             { from: "app.scss" }, // Changed from .css to .scss
             { from: "css/**" },
+            { from: "assets/**" },
             { from: "fonts/**" },
             { from: "**/*.jpg" },
             { from: "**/*.png" },


### PR DESCRIPTION
Fixes #16.

Assets were not being copied over as part of the webpack build process. 