### PR TITLE
Fixing for bundling

### DIFF
--- a/nativescript/gulpfile.js
+++ b/nativescript/gulpfile.js
@@ -36,7 +36,7 @@ gulp.task('resources.Assets', () => {
 });
 
 gulp.task('project.Typescript', () => {
-    return gulp.src([`${SRC}**/*.ts`, '!**/*.tns.*', '!**/*.spec.*', 'references.d.ts'], {follow: true})
+    return gulp.src([`${SRC}**/*.ts`, '!**/*.tns.*', '!**/*.spec.*'], {follow: true})
         // .pipe(debug({title: 'project.Typescript'}))
         .pipe(gulp.dest(DEST));
 });

--- a/nativescript/package.json
+++ b/nativescript/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~4.1.0",
-    "@ngtools/webpack": "1.3.1",
+    "@ngtools/webpack": "~1.5.5",
     "@types/jasmine": "^2.5.47",
     "babel-traverse": "6.25.0",
     "babel-types": "6.25.0",

--- a/nativescript/references.d.ts
+++ b/nativescript/references.d.ts
@@ -1,2 +1,0 @@
-/// <reference path="../node_modules/tns-core-modules/tns-core-modules.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.d.ts" />


### PR DESCRIPTION
This fixes the issue with multiple errors when running the bundling build.

Needed to bump the version of `@ngtools/webpack`  to:

`@ngtools/webpack": "~1.5.3”`
 
It is related to this issue:
https://github.com/webpack/enhanced-resolve/issues/98

Also,
The ref to `tns-core-modules.d.ts`is not needed any more and ref to `lib.d.ts` is handled by:
https://github.com/TeamMaestro/angular-native-seed/blob/master/nativescript/tsconfig.json#L25