### PR TITLE
Include extensions supported into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build truly web and native applications using NativeScript and Angular. This see
 
 Extension                        | Platform
 -------------------------------- | -----------
-`.{html/scss}`                   | Only for web
+`.{html/scss}`                   | Recommended for Web. Does apply to both platforms when **.tns** equivalent does not exist.
 `.tns.{html/scss}`               | Only for mobile
 `.tns.ios.{html/scss}`           | Only for iOS
 `.tns.android.{html/scss}`       | Only for Android

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build truly web and native applications using NativeScript and Angular. This see
 
 Extension                        | Platform
 -------------------------------- | -----------
-`.{html/scss}`                   | All platforms
+`.{html/scss}`                   | Only for web
 `.tns.{html/scss}`               | Only for mobile
 `.tns.ios.{html/scss}`           | Only for iOS
 `.tns.android.{html/scss}`       | Only for Android

--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ Build truly web and native applications using NativeScript and Angular. This see
 - i18n Translations
 - Lazy Loaded Modules
 - Angular CLI // Webpack // Testing
-- Target Phone and Tablet Templates Individually
+- Target Phone and Tablet Templates Individually. The following extensions are supported:
+
+Extension                        | Platform
+-------------------------------- | -----------
+`.{html/scss}`                   | All platforms
+`.tns.{html/scss}`               | Only for mobile
+`.tns.ios.{html/scss}`           | Only for iOS
+`.tns.android.{html/scss}`       | Only for Android
+`.tns.ios.phone.{html/scss}`     | Only for iOS Phone 
+`.tns.android.phone.{html/scss}` | Only for Android Phone
 - Docker build provided using NGINX to serve web content and load balance reverse proxied backends. (See nginx folder for setup instructions)
 
 ## Getting Started


### PR DESCRIPTION
Extension                        | Platform
-------------------------------- | -----------
`.{html/scss}`                   | Recommended for Web. Does apply to both platforms when .tns equivalent does not exist.
`.tns.{html/scss}`               | Only for mobile
`.tns.ios.{html/scss}`           | Only for iOS
`.tns.android.{html/scss}`       | Only for Android
`.tns.ios.phone.{html/scss}`     | Only for iOS Phone 
`.tns.android.phone.{html/scss}` | Only for Android Phone