### PR TITLE
Fixes #93. Remove invalid symlink.

### DIFF
--- a/nativescript/.gitignore
+++ b/nativescript/.gitignore
@@ -13,6 +13,8 @@ app/**/*
 
 src/app
 src/assets
+src/fonts
+
 src/node_modules
 src/platforms
 

--- a/nativescript/src/fonts
+++ b/nativescript/src/fonts
@@ -1,1 +1,0 @@
-/Users/sean/Documents/maestro/angular-native-seed/src/fonts


### PR DESCRIPTION
Awesome work on this seed project and thank you!

I ran into #93 as well and noticed an invalid symlink in the { N } `src`. That was preventing the `fonts` and `assets` symlinks from being created, which would cause the gulp build task to fail.

I also just updated the `.gitignore` in { N } to also ignore the `fonts` symlink, which is probably how the symlink was initially accidentally pushed to begin with :).

Thanks again! 👍 