### PR TITLE
Relative link

### DIFF
--- a/nativescript/src/fonts
+++ b/nativescript/src/fonts
@@ -1,1 +1,1 @@
-/Users/sean/Documents/maestro/angular-native-seed/src/fonts
+../../src/fonts


### PR DESCRIPTION
I catched that error before to do that:
```
[16:21:09] Using gulpfile ~/Code/hybrid-shared/nativescript/gulpfile.js
[16:21:09] Starting 'build.cli.Phone'...
[16:21:09] Starting 'build.Phone'...
[16:21:09] Starting 'build.Default'...
[16:21:09] Starting 'clean.Dist'...
[16:21:09] Finished 'clean.Dist' after 51 ms
[16:21:09] Starting 'resources.App_Resources'...
[16:21:09] Finished 'resources.App_Resources' after 70 ms
[16:21:09] Starting 'resources.Assets'...
[16:21:09] 'resources.Assets' errored after 21 ms
[16:21:09] Error: ENOENT: no such file or directory, stat '/home/ettore/Code/hybrid-shared/nativescript/src/fonts'
[16:21:09] 'build.Default' errored after 144 ms
[16:21:09] 'build.Phone' errored after 144 ms
[16:21:09] 'build.cli.Phone' errored after 146 ms
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! angular-native-seed@0.0.0 prepCLIPhone: `gulp build.cli.Phone`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the angular-native-seed@0.0.0 prepCLIPhone script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ettore/.npm/_logs/2018-08-29T19_21_09_987Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! angular-native-seed@0.0.0 android.phone: `npm run prepCLIPhone && tns run android`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the angular-native-seed@0.0.0 android.phone script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ettore/.npm/_logs/2018-08-29T19_21_11_343Z-debug.log
```